### PR TITLE
playback example: fix a bug where audio is choppy

### DIFF
--- a/_examples/playback/playback.go
+++ b/_examples/playback/playback.go
@@ -79,7 +79,7 @@ func main() {
 	sampleSize := uint32(malgo.SampleSizeInBytes(deviceConfig.Format))
 	// This is the function that's used for sending more data to the device for playback.
 	onSendSamples := func(frameCount uint32, samples []byte) uint32 {
-		n, _ := reader.Read(samples)
+		n, _ := io.ReadFull(reader, samples)
 		return uint32(n) / uint32(channels) / sampleSize
 	}
 


### PR DESCRIPTION
Fix a bug where audio is choppy because the `samples` buffer passed to the `onSendSamples` callback is not being filled completely.  For this purpose, the `io.ReadFull` wrapper function was used as it blocks until there is enough data to fill the whole buffer (which `mp3.(*Decoder).Read` doesn't seem to be doing).