### PR TITLE
Convert all Malgo structs to Go representations

### DIFF
--- a/_examples/capture/capture.go
+++ b/_examples/capture/capture.go
@@ -27,16 +27,16 @@ func main() {
 	deviceConfig.Playback.Format = malgo.FormatS16
 	deviceConfig.Playback.Channels = 1
 	deviceConfig.SampleRate = 44100
-	deviceConfig.Alsa.NoMMap = 1
+	deviceConfig.Alsa.NoMMap = true
 
-	var playbackSampleCount uint32
-	var capturedSampleCount uint32
+	var playbackSampleCount int
+	var capturedSampleCount int
 	pCapturedSamples := make([]byte, 0)
 
-	sizeInBytes := uint32(malgo.SampleSizeInBytes(deviceConfig.Capture.Format))
+	sizeInBytes := malgo.SampleSizeInBytes(deviceConfig.Capture.Format)
 	onRecvFrames := func(pSample2, pSample []byte, framecount uint32) {
 
-		sampleCount := framecount * deviceConfig.Capture.Channels * sizeInBytes
+		sampleCount := int(framecount) * deviceConfig.Capture.Channels * sizeInBytes
 
 		newCapturedSampleCount := capturedSampleCount + sampleCount
 
@@ -68,7 +68,7 @@ func main() {
 	device.Uninit()
 
 	onSendFrames := func(pSample, nil []byte, framecount uint32) {
-		samplesToRead := framecount * deviceConfig.Playback.Channels * sizeInBytes
+		samplesToRead := int(framecount) * deviceConfig.Playback.Channels * sizeInBytes
 		if samplesToRead > capturedSampleCount-playbackSampleCount {
 			samplesToRead = capturedSampleCount - playbackSampleCount
 		}
@@ -77,7 +77,7 @@ func main() {
 
 		playbackSampleCount += samplesToRead
 
-		if playbackSampleCount == uint32(len(pCapturedSamples)) {
+		if playbackSampleCount == len(pCapturedSamples) {
 			playbackSampleCount = 0
 		}
 	}

--- a/_examples/enumeration/enumeration.go
+++ b/_examples/enumeration/enumeration.go
@@ -33,7 +33,7 @@ func main() {
 			e = err.Error()
 		}
 		fmt.Printf("    %d: %v, %s, [%s], channels: %d-%d, samplerate: %d-%d\n",
-			i, info.ID, info.Name(), e, full.MinChannels, full.MaxChannels, full.MinSampleRate, full.MaxSampleRate)
+			i, info.ID, info.Name, e, full.MinChannels, full.MaxChannels, full.MinSampleRate, full.MaxSampleRate)
 	}
 
 	fmt.Println()
@@ -53,6 +53,6 @@ func main() {
 			e = err.Error()
 		}
 		fmt.Printf("    %d: %v, %s, [%s], channels: %d-%d, samplerate: %d-%d\n",
-			i, info.ID, info.Name(), e, full.MinChannels, full.MaxChannels, full.MinSampleRate, full.MaxSampleRate)
+			i, info.ID, info.Name, e, full.MinChannels, full.MaxChannels, full.MinSampleRate, full.MaxSampleRate)
 	}
 }

--- a/_examples/io_api/stream_config.go
+++ b/_examples/io_api/stream_config.go
@@ -17,11 +17,11 @@ func (config StreamConfig) asDeviceConfig(deviceType malgo.DeviceType) malgo.Dev
 		deviceConfig.Playback.Format = config.Format
 	}
 	if config.Channels != 0 {
-		deviceConfig.Capture.Channels = uint32(config.Channels)
-		deviceConfig.Playback.Channels = uint32(config.Channels)
+		deviceConfig.Capture.Channels = config.Channels
+		deviceConfig.Playback.Channels = config.Channels
 	}
 	if config.SampleRate != 0 {
-		deviceConfig.SampleRate = uint32(config.SampleRate)
+		deviceConfig.SampleRate = config.SampleRate
 	}
 	return deviceConfig
 }

--- a/_examples/playback/playback.go
+++ b/_examples/playback/playback.go
@@ -28,7 +28,7 @@ func main() {
 	defer file.Close()
 
 	var reader io.Reader
-	var channels, sampleRate uint32
+	var channels, sampleRate int
 
 	switch strings.ToLower(filepath.Ext(os.Args[1])) {
 	case ".wav":
@@ -40,8 +40,8 @@ func main() {
 		}
 
 		reader = w
-		channels = uint32(f.NumChannels)
-		sampleRate = f.SampleRate
+		channels = int(f.NumChannels)
+		sampleRate = int(f.SampleRate)
 
 	case ".mp3":
 		m, err := mp3.NewDecoder(file)
@@ -52,13 +52,13 @@ func main() {
 
 		reader = m
 		channels = 2
-		sampleRate = uint32(m.SampleRate())
+		sampleRate = m.SampleRate()
 	default:
 		fmt.Println("Not a valid file.")
 		os.Exit(1)
 	}
 
-	ctx, err := malgo.InitContext(nil, malgo.ContextConfig{}, func(message string) {
+	ctx, err := malgo.InitContext(nil, malgo.NewContextConfig(), func(message string) {
 		fmt.Printf("LOG <%v>\n", message)
 	})
 	if err != nil {
@@ -74,7 +74,7 @@ func main() {
 	deviceConfig.Playback.Format = malgo.FormatS16
 	deviceConfig.Playback.Channels = channels
 	deviceConfig.SampleRate = sampleRate
-	deviceConfig.Alsa.NoMMap = 1
+	deviceConfig.Alsa.NoMMap = true
 
 	// This is the function that's used for sending more data to the device for playback.
 	onSamples := func(pOutputSample, pInputSamples []byte, framecount uint32) {

--- a/callbacks.c
+++ b/callbacks.c
@@ -1,0 +1,29 @@
+#include "_cgo_export.h"
+#include "miniaudio.h"
+#include "callbacks.h"
+extern void goLogCallbackWrapper(ma_context* pContext, ma_device* pDevice, ma_uint32 logLevel, const char* message) {
+	goLogCallback(pContext, pDevice, logLevel, (char*)(message)); // cast to remove const qualifier that  Go doesn't know how to handle
+}
+extern void goDataCallbackWrapper(ma_device* pDevice, void* pOutput, const void* pInput, ma_uint32 frameCount) {
+	// calculate the buffers size here to avoid C > Go > C calls
+	ma_uint64 outputSizeInBytes, inputSizeInBytes;
+	ma_uint32 outputSampleSizeInBytes, inputSampleSizeInBytes;
+	outputSampleSizeInBytes = 0;
+	inputSampleSizeInBytes = 0;
+	outputSizeInBytes = 0;
+	inputSizeInBytes = 0;
+	if (pOutput != NULL) {
+		ma_uint32 sampleCount = frameCount * pDevice->playback.channels;
+		outputSampleSizeInBytes = ma_get_bytes_per_sample(pDevice->playback.format);
+		outputSizeInBytes = (ma_uint64)(outputSampleSizeInBytes * sampleCount);
+	}
+	if (pInput != NULL) {
+		ma_uint32 sampleCount = frameCount * pDevice->capture.channels;
+inputSampleSizeInBytes = ma_get_bytes_per_sample(pDevice->capture.format);
+		inputSizeInBytes = (ma_uint64)(inputSampleSizeInBytes * sampleCount);
+	}
+	goDataCallback(pDevice, pOutput, (void*)(pInput), frameCount, outputSizeInBytes, inputSizeInBytes);
+}
+extern void goStopCallbackWrapper(ma_device* pDevice) {
+	goStopCallback(pDevice);
+}

--- a/callbacks.c
+++ b/callbacks.c
@@ -2,7 +2,7 @@
 #include "miniaudio.h"
 #include "callbacks.h"
 extern void goLogCallbackWrapper(ma_context* pContext, ma_device* pDevice, ma_uint32 logLevel, const char* message) {
-	goLogCallback(pContext, pDevice, logLevel, (char*)(message)); // cast to remove const qualifier that  Go doesn't know how to handle
+	goLogCallback(pContext, pDevice, (char*)(message)); // cast to remove const qualifier that  Go doesn't know how to handle
 }
 extern void goDataCallbackWrapper(ma_device* pDevice, void* pOutput, const void* pInput, ma_uint32 frameCount) {
 	// calculate the buffers size here to avoid C > Go > C calls

--- a/callbacks.h
+++ b/callbacks.h
@@ -1,0 +1,4 @@
+#include "miniaudio.h"
+extern void goLogCallbackWrapper(ma_context* pContext, ma_device* pDevice, ma_uint32 logLevel, const char* message);
+extern void goDataCallbackWrapper(ma_device* pDevice, void* pOutput, const void* pInput, ma_uint32 frameCount);
+extern void goStopCallbackWrapper(ma_device* pDevice);

--- a/context.go
+++ b/context.go
@@ -46,9 +46,9 @@ type internalContextInfo struct {
 
 
 // Initializes a new ContextConfig with defaults. You must call this instead of creating a ContextConfig object directly.
-func NewContextConfig() *ContextConfig {
+func NewContextConfig() ContextConfig {
 	cConfig := C.ma_context_config_init()
-	config := &ContextConfig{}
+	config := ContextConfig{}
 	config.Alsa.UseVerboseDeviceEnumeration = intToBool(cConfig.alsa.useVerboseDeviceEnumeration)
 
 	config.Pulse.ApplicationName = goString(cConfig.pulse.pApplicationName)
@@ -136,7 +136,7 @@ func (ctx Context) Devices(kind DeviceType) ([]DeviceInfo, error) {
 	info := make([]DeviceInfo, deviceCount)
 	deviceInfoAddr := uintptr(unsafe.Pointer(devices))
 	for i := 0; i < deviceCount; i++ {
-		info[i] = deviceInfoFromPointer(unsafe.Pointer(deviceInfoAddr))
+		info[i] = deviceInfoFromCRepr(*(*C.ma_device_info)(unsafe.Pointer(deviceInfoAddr)))
 		deviceInfoAddr += rawDeviceInfoSize
 	}
 
@@ -153,9 +153,9 @@ func (ctx Context) DeviceInfo(kind DeviceType, id DeviceID, mode ShareMode) (Dev
 		return DeviceInfo{}, err
 	}
 
-	return deviceInfoFromPointer(unsafe.Pointer(&info)), nil
+	return deviceInfoFromCRepr(info), nil
 }
-// for making some context functions like getDevics threadsafe
+// for making some context functions like getDevice threadsafe
 var contextMutex sync.Mutex
 
 

--- a/device_config.go
+++ b/device_config.go
@@ -2,84 +2,167 @@ package malgo
 
 // #include "malgo.h"
 import "C"
-import "unsafe"
+import (
+	"unsafe"
+	"time"
+)
 
-// DeviceConfig type.
 type DeviceConfig struct {
-	DeviceType               DeviceType
-	SampleRate               uint32
-	PeriodSizeInFrames       uint32
-	PeriodSizeInMilliseconds uint32
-	Periods                  uint32
-	PerformanceProfile       PerformanceProfile
-	NoPreZeroedOutputBuffer  uint32
-	NoClip                   uint32
-	DataCallback             *[0]byte
-	StopCallback             *[0]byte
-	PUserData                *byte
-	Resampling               ResampleConfig
-	Playback                 SubConfig
-	Capture                  SubConfig
-	Wasapi                   WasapiDeviceConfig
-	Alsa                     AlsaDeviceConfig
-	Pulse                    PulseDeviceConfig
+	DeviceType              DeviceType
+	SampleRate              int
+	PeriodSizeInFrames      int
+	PeriodSizeInDuration    time.Duration
+	Periods                 int
+	PerformanceProfile      int
+	NoPreZeroedOutputBuffer bool
+	NoClip                  bool
+	Playback                struct {
+		DeviceID       *DeviceID
+		Format         FormatType
+		Channels       int
+		ChannelMap     [C.MA_MAX_CHANNELS]uint8
+		ShareMode      int
+		ChannelMixMode int
+	}
+	Capture struct {
+		DeviceID       *DeviceID
+		Format         FormatType
+		Channels       int
+		ChannelMap     [C.MA_MAX_CHANNELS]uint8
+		ShareMode      int
+		ChannelMixMode int
+	}
+	Wasapi struct {
+		NoAutoConvertSRC     bool
+		NoDefaultQualitySRC  bool
+		NoAutoStreamRouting  bool
+		NoHardwareOffloading bool
+	}
+	Alsa struct {
+		NoMMap         bool
+		NoAutoFormat   bool
+		NoAutoChannels bool
+		NoAutoResample bool
+	}
+	Pulse struct {
+		StreamNamePlayback string
+		StreamNameCapture  string
+	}
+	CoreAudio struct {
+		AllowNominalSampleRateChange bool
+	}
+	Opensl struct {
+		StreamType      int
+		RecordingPreset int
+	}
+	Aaudio struct {
+		Usage       int
+		ContentType int
+		InputPreset int
+	}
+	Resampling struct {
+		Algorithm int
+		Linear    struct {
+			LPFOrder int
+		}
+		Speex struct {
+			Quality int
+		}
+	}
 }
-
 // DefaultDeviceConfig returns a default device config.
 func DefaultDeviceConfig(deviceType DeviceType) DeviceConfig {
-	config := C.ma_device_config_init(C.ma_device_type(deviceType))
-	return *(*DeviceConfig)(unsafe.Pointer(&config))
+	cConfig := C.ma_device_config_init(C.ma_device_type(deviceType))
+	config := DeviceConfig{}
+	config.DeviceType = DeviceType(cConfig.deviceType)
+	config.SampleRate = int(cConfig.sampleRate)
+	config.PeriodSizeInFrames = int(cConfig.periodSizeInFrames)
+	config.PeriodSizeInDuration = time.Millisecond * time.Duration(cConfig.periodSizeInMilliseconds)
+	config.Periods = int(cConfig.periods)
+	config.PerformanceProfile = int(cConfig.performanceProfile)
+	config.NoPreZeroedOutputBuffer = int8ToBool(cConfig.noPreZeroedOutputBuffer)
+	config.NoClip = int8ToBool(cConfig.noClip)
+	config.Resampling.Algorithm = int(cConfig.resampling.algorithm)
+	config.Resampling.Linear.LPFOrder = int(cConfig.resampling.linear.lpfOrder)
+	config.Resampling.Speex.Quality = int(cConfig.resampling.speex.quality)
+	config.Wasapi.NoAutoConvertSRC = int8ToBool(cConfig.wasapi.noAutoConvertSRC)
+	config.Wasapi.NoDefaultQualitySRC = int8ToBool(cConfig.wasapi.noDefaultQualitySRC)
+	config.Wasapi.NoAutoStreamRouting = int8ToBool(cConfig.wasapi.noAutoStreamRouting)
+	config.Wasapi.NoHardwareOffloading = int8ToBool(cConfig.wasapi.noHardwareOffloading)
+	config.Alsa.NoMMap = intToBool(cConfig.alsa.noMMap)
+	config.Alsa.NoAutoFormat = intToBool(cConfig.alsa.noAutoFormat)
+	config.Alsa.NoAutoChannels = intToBool(cConfig.alsa.noAutoChannels)
+	config.Alsa.NoAutoResample = intToBool(cConfig.alsa.noAutoResample)
+	config.Pulse.StreamNameCapture = goString(cConfig.pulse.pStreamNameCapture)
+	config.Pulse.StreamNamePlayback = goString(cConfig.pulse.pStreamNamePlayback)
+	config.CoreAudio.AllowNominalSampleRateChange = intToBool(cConfig.coreaudio.allowNominalSampleRateChange)
+	config.Opensl.StreamType = int(cConfig.opensl.streamType)
+	config.Opensl.RecordingPreset = int(cConfig.opensl.recordingPreset)
+	config.Aaudio.ContentType = int(cConfig.aaudio.contentType)
+	config.Aaudio.InputPreset = int(cConfig.aaudio.inputPreset)
+
+	return config
 }
 
-func (d *DeviceConfig) cptr() *C.ma_device_config {
-	return (*C.ma_device_config)(unsafe.Pointer(d))
-}
+func (config *DeviceConfig) toCRepr() (C.ma_device_config, pointerList) {
+	// even if we forget to initialize some fields, telling Miniaudio to reinitialize the config ensures it doesn't break anything
+	// a list of pointers that holds any memory allocated by the config like strings and deviceIDs ETC. This is returned alongside the new cConfig, is stored in the DeviceCallbacks struct and freed when Device.Uninit() is called
+	var memory pointerList
+	cConfig := C.ma_device_config_init(C.ma_device_type(config.DeviceType))
+	cConfig.periodSizeInFrames = C.ma_uint32(config.PeriodSizeInFrames)
+	cConfig.periodSizeInMilliseconds = C.ma_uint32(config.PeriodSizeInDuration.Milliseconds())
+	cConfig.periods = C.ma_uint32(config.Periods)
+	cConfig.performanceProfile = C.ma_performance_profile(config.PerformanceProfile)
+	cConfig.noPreZeroedOutputBuffer = boolToInt8(config.NoPreZeroedOutputBuffer)
+	cConfig.noClip = boolToInt8(config.NoClip)
+	cConfig.resampling.algorithm = C.ma_resample_algorithm(config.Resampling.Algorithm)
 
-// SubConfig type.
-type SubConfig struct {
-	DeviceID   unsafe.Pointer
-	Format     FormatType
-	Channels   uint32
-	ChannelMap [C.MA_MAX_CHANNELS]uint8
-	ShareMode  ShareMode
-	_          [4]byte // cgo padding
-}
+	cConfig.resampling.linear.lpfOrder = C.ma_uint32(config.Resampling.Linear.LPFOrder)
 
-// WasapiDeviceConfig type.
-type WasapiDeviceConfig struct {
-	NoAutoConvertSRC     uint32
-	NoDefaultQualitySRC  uint32
-	NoAutoStreamRouting  uint32
-	NoHardwareOffloading uint32
-}
+	cConfig.resampling.speex.quality = C.int(config.Resampling.Speex.Quality)
+	if config.Playback.DeviceID != nil {
+		// the below device ID is stored in memory, whos pointers are freed when the user calls Device.Free.
+		cConfig.playback.pDeviceID = (*C.ma_device_id)(unsafe.Pointer(memory.cbytes(config.Playback.DeviceID[:])))
+	}
+	cConfig.playback.format = C.ma_format(config.Playback.Format)
+	cConfig.playback.channels = C.ma_uint32(config.Playback.Channels)
+	for i, v := range config.Playback.ChannelMap {
+		cConfig.playback.channelMap[i] = C.ma_channel(v)
+	}
+	cConfig.playback.channelMixMode = C.ma_channel_mix_mode(config.Playback.ChannelMixMode)
+	cConfig.playback.shareMode = C.ma_share_mode(config.Playback.ShareMode)
 
-// AlsaDeviceConfig type.
-type AlsaDeviceConfig struct {
-	NoMMap         uint32
-	NoAutoFormat   uint32
-	NoAutoChannles uint32
-	NoAutoResample uint32
-}
+	if config.Capture.DeviceID != nil {
+		cConfig.capture.pDeviceID = (*C.ma_device_id)(unsafe.Pointer(memory.cbytes(config.Capture.DeviceID[:])))
+	}
+	cConfig.capture.format = C.ma_format(config.Capture.Format)
+	cConfig.capture.channels = C.ma_uint32(config.Capture.Channels)
+	for i, v := range config.Capture.ChannelMap {
+		cConfig.capture.channelMap[i] = C.ma_channel(v)
+	}
+	cConfig.capture.channelMixMode = C.ma_channel_mix_mode(config.Capture.ChannelMixMode)
+	cConfig.capture.shareMode = C.ma_share_mode(config.Capture.ShareMode)
 
-// PulseDeviceConfig type.
-type PulseDeviceConfig struct {
-	StreamNamePlayback *int8
-	StreamNameCapture  *int8
-}
+	cConfig.wasapi.noAutoConvertSRC = boolToInt8(config.Wasapi.NoAutoConvertSRC)
+	cConfig.wasapi.noDefaultQualitySRC = boolToInt8(config.Wasapi.NoDefaultQualitySRC)
+	cConfig.wasapi.noAutoStreamRouting = boolToInt8(config.Wasapi.NoAutoStreamRouting)
+	cConfig.wasapi.noHardwareOffloading = boolToInt8(config.Wasapi.NoHardwareOffloading)
 
-// ResampleConfig type.
-type ResampleConfig struct {
-	Algorithm ResampleAlgorithm
-	Linear    ResampleLinearConfig
-	Speex     ResampleSpeexConfig
-}
+	cConfig.alsa.noMMap = boolToInt(config.Alsa.NoMMap)
+	cConfig.alsa.noAutoFormat = boolToInt(config.Alsa.NoAutoFormat)
+	cConfig.alsa.noAutoChannels = boolToInt(config.Alsa.NoAutoChannels)
+	cConfig.alsa.noAutoResample = boolToInt(config.Alsa.NoAutoResample)
 
-// ResampleLinearConfig type.
-type ResampleLinearConfig struct {
-	LpfOrder uint32
-}
+	cConfig.pulse.pStreamNamePlayback = memory.cString(config.Pulse.StreamNamePlayback)
+	cConfig.pulse.pStreamNameCapture = memory.cString(config.Pulse.StreamNameCapture)
 
-// ResampleSpeexConfig type.
-type ResampleSpeexConfig struct {
-	Quality int
+	cConfig.coreaudio.allowNominalSampleRateChange = boolToInt(config.CoreAudio.AllowNominalSampleRateChange)
+
+	cConfig.opensl.streamType = C.ma_opensl_stream_type(config.Opensl.StreamType)
+	cConfig.opensl.recordingPreset = C.ma_opensl_recording_preset(config.Opensl.RecordingPreset)
+
+	cConfig.aaudio.usage = C.ma_aaudio_usage(config.Aaudio.Usage)
+	cConfig.aaudio.contentType = C.ma_aaudio_content_type(config.Aaudio.ContentType)
+	cConfig.aaudio.inputPreset = C.ma_aaudio_input_preset(config.Aaudio.InputPreset)
+	return cConfig, memory
 }

--- a/malgo.h
+++ b/malgo.h
@@ -2,7 +2,7 @@
 #define H_MALGO
 
 #include "miniaudio.h"
-
+#include "callbacks.h" // definitions of our callbacks
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/malgo.h
+++ b/malgo.h
@@ -6,14 +6,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-extern void goLogCallback(ma_context* pContext, ma_device* pDevice, char* message);
-void goSetContextConfigCallbacks(ma_context_config* pConfig);
-
-extern void goDataCallback(ma_device *pDevice, void *pOutput, void *pInput, ma_uint32 frameCount);
-extern void goStopCallback(ma_device* pDevice);
-void goSetDeviceConfigCallbacks(ma_device_config* pConfig);
-
 #ifdef __cplusplus
 }
 #endif

--- a/miniaudio.c
+++ b/miniaudio.c
@@ -2,24 +2,3 @@
 
 #define MINIAUDIO_IMPLEMENTATION
 #include "miniaudio.h"
-
-static void goLogCallbackWrapper(ma_context *pContext, ma_device *pDevice, 
-                                 ma_uint32 logLevel, const char *message) {
-    goLogCallback(pContext, pDevice, (char *)message);
-}
-
-void goSetContextConfigCallbacks(ma_context_config* pConfig) {
-    pConfig->logCallback = goLogCallbackWrapper;
-}
-
-static void goDataCallbackWrapper(ma_device *pDevice,
-                                  void *pOutput, const void *pInput,
-                                  ma_uint32 frames)
-{
-    goDataCallback(pDevice, pOutput, (void *)pInput, frames);
-}
-
-void goSetDeviceConfigCallbacks(ma_device_config* pConfig) {
-    pConfig->dataCallback = goDataCallbackWrapper;
-    pConfig->stopCallback = goStopCallback;
-}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,79 @@
+// a bunch of things to help with working with CGO and CGO types
+
+package malgo
+import (
+	"unsafe"
+)
+/*
+#include <stdlib.h>
+#include "miniaudio.h"
+*/
+import "C"
+
+func goString(ptr *C.char) string {
+	if ptr == nil {
+		return ""
+	} else {
+		return C.GoString(ptr)
+	}
+}
+func cString(value string) *C.char {
+	if len(value) == 0 {
+		return nil
+	} else {
+		return C.CString(value)
+	}
+}
+func freeCString(ptr *C.char) {
+	if ptr == nil {
+		return
+	} else {
+		C.free(unsafe.Pointer(ptr))
+	}
+}
+func intToBool(value C.ma_bool32) bool {
+	return value != 0
+}
+func boolToInt(value bool) C.ma_bool32 {
+	switch value {
+		case false: return 0
+		case true: return 1
+	}
+	return 0
+}
+func int8ToBool(value C.ma_bool8) bool {
+	return value != 0
+}
+func boolToInt8(value bool) C.ma_bool8 {
+	switch value {
+		case false: return 0
+		default: return 1
+	}
+}
+// a list of pointers to C allocated memory that makes it easy to associate a bunch of pointers with something like a context and then free them all at once
+type pointerList []unsafe.Pointer
+// allocates a new cString and adds it to self
+func (self *pointerList) cString(value string) *C.char {
+	ptr := cString(value)
+	self.addPointer(unsafe.Pointer(ptr))
+	return ptr
+}
+func (self *pointerList) addPointer(ptr unsafe.Pointer ) {
+	if ptr != nil {
+		*self = append(*self, ptr)
+	}
+}
+// allocates value into C bytes, adds the ptr to self and returns ptr
+func (self *pointerList) cbytes(value []byte) unsafe.Pointer {
+	ptr := C.CBytes(value)
+	self.addPointer(ptr)
+	return ptr
+}
+// empties self and frees all the associated pointers
+// self is still useable after calling free
+func (self *pointerList) free() {
+	for _, i := range *self {
+		C.free(i)
+	}
+	*self = (*self)[:0] // self is now empty
+}


### PR DESCRIPTION
This changes the ContextConfig, DeviceConfig and DeviceInfo structs to use Go types which are easier to use, require less integer conversion, safer, and we use CGO to figure out struct field offsets by manually converting structs so everything will work properly when Miniaudio updates.
This is a breaking change because the types and names of many fields of the before mentioned structs have changed. Everything else should still be the same.
Also move all the callback stuff from miniaudio.c and malgo.h into callbacks.c and callbacks.h to make things tidier.