### PR TITLE
Make internal error handling more robust

### DIFF
--- a/context.go
+++ b/context.go
@@ -79,7 +79,7 @@ func (ctx Context) cptr() *C.ma_context {
 // Results are undefined if you call this while any device created by this context is still active.
 func (ctx Context) Uninit() error {
 	result := C.ma_context_uninit(ctx.cptr())
-	return errorFromResult(Result(result))
+	return errorFromResult(result)
 }
 
 // Devices retrieves basic information about every active playback or capture device.
@@ -95,7 +95,7 @@ func (ctx Context) Devices(kind DeviceType) ([]DeviceInfo, error) {
 	result := C.ma_context_get_devices(ctx.cptr(),
 		&playbackDevices, &playbackDeviceCount,
 		&captureDevices, &captureDeviceCount)
-	err := errorFromResult(Result(result))
+	err := errorFromResult(result)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (ctx Context) DeviceInfo(kind DeviceType, id DeviceID, mode ShareMode) (Dev
 	var info C.ma_device_info
 
 	result := C.ma_context_get_device_info(ctx.cptr(), C.ma_device_type(kind), id.cptr(), C.ma_share_mode(mode), &info)
-	err := errorFromResult(Result(result))
+	err := errorFromResult(result)
 	if err != nil {
 		return DeviceInfo{}, err
 	}
@@ -179,7 +179,7 @@ func InitContext(backends []Backend, config ContextConfig, logProc LogProc) (*Al
 	}
 
 	result := C.ma_context_init(backendsArg, backendCountArg, config.cptr(), ctx.cptr())
-	err := errorFromResult(Result(result))
+	err := errorFromResult(result)
 	if err != nil {
 		ctx.SetLogProc(nil)
 		ctx.Free()

--- a/device.go
+++ b/device.go
@@ -44,7 +44,7 @@ func InitDevice(context Context, deviceConfig DeviceConfig, deviceCallbacks Devi
 	result := C.ma_device_init(context.cptr(), deviceConfig.cptr(), rawDevice)
 	if result != 0 {
 		dev.free()
-		return nil, errorFromResult(Result(result))
+		return nil, errorFromResult(result)
 	}
 	deviceMutex.Lock()
 	dataCallbacks[rawDevice] = deviceCallbacks.Data
@@ -103,7 +103,7 @@ func (dev *Device) SampleRate() uint32 {
 // waits on a mutex for thread-safety.
 func (dev *Device) Start() error {
 	result := C.ma_device_start(dev.cptr())
-	return errorFromResult(Result(result))
+	return errorFromResult(result)
 }
 
 // IsStarted determines whether or not the device is started.
@@ -120,7 +120,7 @@ func (dev *Device) IsStarted() bool {
 // the buffer size that was specified at initialization time).
 func (dev *Device) Stop() error {
 	result := C.ma_device_stop(dev.cptr())
-	return errorFromResult(Result(result))
+	return errorFromResult(result)
 }
 
 // Uninit uninitializes a device.

--- a/enumerations.go
+++ b/enumerations.go
@@ -82,6 +82,9 @@ const (
 // Result type.
 type Result int32
 
+func (self Result) Error() string {
+	return goString(C.ma_get_Result_description(C.ma_result(self)))
+}
 
 // ResampleAlgorithm type.
 type ResampleAlgorithm uint32

--- a/enumerations.go
+++ b/enumerations.go
@@ -1,5 +1,10 @@
 package malgo
 
+/*
+#include "malgo.h"
+*/
+import "C"
+
 // Backend type.
 type Backend uint32
 
@@ -83,7 +88,7 @@ const (
 type Result int32
 
 func (self Result) Error() string {
-	return goString(C.ma_get_Result_description(C.ma_result(self)))
+	return C.GoString(C.ma_result_description(C.ma_result(self)))
 }
 
 // ResampleAlgorithm type.

--- a/enumerations.go
+++ b/enumerations.go
@@ -1,9 +1,5 @@
 package malgo
 
-/*
-#include "malgo.h"
-*/
-import "C"
 
 // Backend type.
 type Backend uint32
@@ -83,14 +79,6 @@ const (
 
 	ThreadPriorityDefault ThreadPriority = 0
 )
-
-// Result type.
-type Result int32
-
-func (self Result) Error() string {
-	return C.GoString(C.ma_result_description(C.ma_result(self)))
-}
-
 // ResampleAlgorithm type.
 type ResampleAlgorithm uint32
 

--- a/enumerations.go
+++ b/enumerations.go
@@ -82,50 +82,6 @@ const (
 // Result type.
 type Result int32
 
-// Return codes.
-const (
-	Success = 0
-
-	//  General errors.
-	Error            = -1 // a generic error
-	InvalidArgs      = -2
-	InvalidPperation = -3
-	OutOfMemory      = -4
-	AccessDenied     = -5
-	TooLarge         = -6
-	Timeout          = -7
-
-	// General miniaudio-specific errors.
-	FormatNotSupported     = -100
-	DeviceTypeNotSupported = -101
-	ShareModeNotSupported  = -102
-	NoBackend              = -103
-	NoDevice               = -104
-	APINotFound            = -105
-	InvalidDeviceConfig    = -106
-
-	// State errors.
-	DeviceBusy           = -200
-	DeviceNotInitialized = -201
-	DeviceNotStarted     = -202
-	DeviceUnavailable    = -203
-
-	// Operation errors.
-	FailedToMapDeviceBuffer        = -300
-	FailedToUnmapDeviceBuffer      = -301
-	FailedToInitBackend            = -302
-	FailedToReadDataFromDevice     = -304
-	FailedToReadDataFromClient     = -303
-	FailedToSendDataToClient       = -305
-	FailedToSendDataToDevice       = -306
-	FailedToOpenBackendDevice      = -307
-	FailedToStartBackendDevice     = -308
-	FailedToStopBackendDevice      = -309
-	FailedToConfigureBackendDevice = -310
-	FailedToCreateMutex            = -311
-	FailedToCreateEvent            = -312
-	FailedToCreateThread           = -313
-)
 
 // ResampleAlgorithm type.
 type ResampleAlgorithm uint32

--- a/errors.go
+++ b/errors.go
@@ -6,6 +6,15 @@ package malgo
 */
 import "C"
 
+// Result type.
+type Result int32
+
+func (self Result) Error() string {
+	return C.GoString(C.ma_result_description(C.ma_result(self)))
+}
+
+
+
 
 // Errors.
 var (

--- a/errors.go
+++ b/errors.go
@@ -103,11 +103,11 @@ var (
 	ErrFailedToStopBackendDevice      = Result(C.MA_FAILED_TO_STOP_BACKEND_DEVICE)
 )
 // errorFromResult returns error for result code.
-func errorFromResult(r Result) error {
+func errorFromResult(r C.ma_result) error {
 	switch r {
 	case C.MA_SUCCESS:
 		return nil
 	default:
-	return r
+	return Result(r)
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -1,115 +1,104 @@
 package malgo
 
-import "fmt"
+
+/*
+#include "malgo.h"
+*/
+import "C"
+
 
 // Errors.
 var (
 	errTag = "miniaudio"
+	//  General errors.
+	ErrGeneric            = Result(C.MA_ERROR)
+	ErrInvalidArgs      = Result(C.MA_INVALID_ARGS)
+	ErrInvalidOperation = Result(C.MA_INVALID_OPERATION)
+	ErrOutOfMemory      = Result(C.MA_OUT_OF_MEMORY)
+	ErrOutOfRange = Result(C.MA_OUT_OF_RANGE)
+	ErrAccessDenied     = Result(C.MA_ACCESS_DENIED)
+	ErrDoesNotExist = Result(C.MA_DOES_NOT_EXIST)
+	ErrAlreadyExists = Result(C.MA_ALREADY_EXISTS)
+	ErrTooManyOpenFiles = Result(C.MA_TOO_MANY_OPEN_FILES)
+	ErrInvalidFile = Result(C.MA_INVALID_FILE)
+	ErrTooBig         = Result(C.MA_TOO_BIG)
+	ErrPathTooLong = Result(C.MA_PATH_TOO_LONG)
+	ErrNameTooLong = Result(C.MA_NAME_TOO_LONG)
+	ErrNotDirectory = Result(C.MA_NOT_DIRECTORY)
+	ErrIsDirectory = Result(C.MA_IS_DIRECTORY)
+	ErrDirectoryNotEmpty = Result(C.MA_DIRECTORY_NOT_EMPTY)
+	ErrEndOfFile = Result(C.MA_END_OF_FILE)
+	ErrNoSpace = Result(C.MA_NO_SPACE)
+	ErrBusy = Result(C.MA_BUSY)
+	ErrIO = Result(C.MA_IO_ERROR)
+	ErrInterrupt = Result(C.MA_INTERRUPT)
+	ErrUnavailable = Result(C.MA_UNAVAILABLE)
+	ErrAlreadyInUse = Result(C.MA_ALREADY_IN_USE)
+	ErrBadAddress = Result(C.MA_BAD_ADDRESS)
+	ErrBadSeek = Result(C.MA_BAD_SEEK)
+	ErrBadPipe = Result(C.MA_BAD_PIPE)
+	ErrDeadlock = Result(C.MA_DEADLOCK)
+	ErrTooManyLinks = Result(C.MA_TOO_MANY_LINKS)
+	ErrNotImplemented = Result(C.MA_NOT_IMPLEMENTED)
+	ErrNoMessage = Result(C.MA_NO_MESSAGE)
+	ErrBadMessage = Result(C.MA_BAD_MESSAGE)
+	ErrNoDataAvailable = Result(C.MA_NO_DATA_AVAILABLE)
+	ErrInvalidData = Result(C.MA_INVALID_DATA)
+	ErrTimeout = Result(C.MA_TIMEOUT)
+	ErrNetwork = Result(C.MA_NO_NETWORK)
+	ErrNotUnique = Result(C.MA_NOT_UNIQUE)
+	ErrNotSocket = Result(C.MA_NOT_SOCKET)
+	ErrNoAddress = Result(C.MA_NO_ADDRESS)
+	ErrBadProtocol = Result(C.MA_BAD_PROTOCOL)
+	ErrProtocolUnavailable = Result(C.MA_PROTOCOL_UNAVAILABLE)
+	ErrProtocolNotSupported = Result(C.MA_PROTOCOL_NOT_SUPPORTED)
+	ErrProtocolFamilyNotSupported = Result(C.MA_PROTOCOL_FAMILY_NOT_SUPPORTED)
+	ErrAddressFamilyNotSupported = Result(C.MA_ADDRESS_FAMILY_NOT_SUPPORTED)
+	ErrSocketNotSupported = Result(C.MA_SOCKET_NOT_SUPPORTED)
+	ErrConnectionReset = Result(C.MA_CONNECTION_RESET)
+	ErrAlreadyConnected = Result(C.MA_ALREADY_CONNECTED)
+	ErrNotConnected = Result(C.MA_NOT_CONNECTED)
+	ErrConnectionRefused = Result(C.MA_CONNECTION_REFUSED)
+	ErrNoHost = Result(C.MA_NO_HOST)
+	ErrInProgress = Result(C.MA_IN_PROGRESS)
+	ErrCancelled = Result(C.MA_CANCELLED)
+	ErrMemoryAlreadyMapped = Result(C.MA_MEMORY_ALREADY_MAPPED)
+	ErrAtEnd = Result(C.MA_AT_END)
 
-	ErrError                          = fmt.Errorf("%s: generic error", errTag)
-	ErrInvalidArgs                    = fmt.Errorf("%s: invalid args", errTag)
-	ErrInvalidPperation               = fmt.Errorf("%s: invalid pperation", errTag)
-	ErrOutOfMemory                    = fmt.Errorf("%s: out o fmemory", errTag)
-	ErrAccessDenied                   = fmt.Errorf("%s: access denied", errTag)
-	ErrTooLarge                       = fmt.Errorf("%s: too large", errTag)
-	ErrTimeout                        = fmt.Errorf("%s: timeout", errTag)
-	ErrFormatNotSupported             = fmt.Errorf("%s: format not supported", errTag)
-	ErrDeviceTypeNotSupported         = fmt.Errorf("%s: device type not supported", errTag)
-	ErrShareModeNotSupported          = fmt.Errorf("%s: share mode not supported", errTag)
-	ErrNoBackend                      = fmt.Errorf("%s: no backend", errTag)
-	ErrNoDevice                       = fmt.Errorf("%s: no device", errTag)
-	ErrAPINotFound                    = fmt.Errorf("%s: api not found", errTag)
-	ErrInvalidDeviceConfig            = fmt.Errorf("%s: invalid device config", errTag)
-	ErrDeviceBusy                     = fmt.Errorf("%s: device busy", errTag)
-	ErrDeviceNotInitialized           = fmt.Errorf("%s: device not initialized", errTag)
-	ErrDeviceNotStarted               = fmt.Errorf("%s: device not started", errTag)
-	ErrDeviceUnavailable              = fmt.Errorf("%s: device unavailable", errTag)
-	ErrFailedToMapDeviceBuffer        = fmt.Errorf("%s: failed to map device buffer", errTag)
-	ErrFailedToUnmapDeviceBuffer      = fmt.Errorf("%s: failed to unmap device buffer", errTag)
-	ErrFailedToInitBackend            = fmt.Errorf("%s: failed to init backend", errTag)
-	ErrFailedToReadDataFromDevice     = fmt.Errorf("%s: failed to read data from device", errTag)
-	ErrFailedToReadDataFromClient     = fmt.Errorf("%s: failed to read data from client", errTag)
-	ErrFailedToSendDataToClient       = fmt.Errorf("%s: failed to send data to client", errTag)
-	ErrFailedToSendDataToDevice       = fmt.Errorf("%s: failed to send data to device", errTag)
-	ErrFailedToOpenBackendDevice      = fmt.Errorf("%s: failed to open backend device", errTag)
-	ErrFailedToStartBackendDevice     = fmt.Errorf("%s: failed to start backend device", errTag)
-	ErrFailedToStopBackendDevice      = fmt.Errorf("%s: failed to stop backend device", errTag)
-	ErrFailedToConfigureBackendDevice = fmt.Errorf("%s: failed to configure backend device", errTag)
-	ErrFailedToCreateMutex            = fmt.Errorf("%s: failed to create mutex", errTag)
-	ErrFailedToCreateEvent            = fmt.Errorf("%s: failed to create event", errTag)
-	ErrFailedToCreateThread           = fmt.Errorf("%s: failed to create thread", errTag)
+
+
+
+
+
+	// General miniaudio-specific errors.
+	ErrFormatNotSupported     = Result(C.MA_FORMAT_NOT_SUPPORTED)
+	ErrDeviceTypeNotSupported = Result(C.MA_DEVICE_TYPE_NOT_SUPPORTED)
+	ErrShareModeNotSupported  = Result(C.MA_SHARE_MODE_NOT_SUPPORTED)
+	ErrNoBackend              = Result(C.MA_NO_BACKEND)
+	ErrNoDevice               = Result(C.MA_NO_DEVICE)
+	ErrAPINotFound            = Result(C.MA_API_NOT_FOUND)
+	ErrInvalidDeviceConfig    = Result(C.MA_INVALID_DEVICE_CONFIG)
+
+	// State errors.
+
+	ErrDeviceNotInitialized = Result(C.MA_DEVICE_NOT_INITIALIZED)
+	ErrDeviceAlreadyInitialized = Result(C.MA_DEVICE_ALREADY_INITIALIZED)
+	ErrDeviceNotStarted     = Result(C.MA_DEVICE_NOT_STARTED)
+	ErrDeviceNotStopped = Result(C.MA_DEVICE_NOT_STOPPED)
+
+	// Operation errors.
+
+	ErrFailedToInitBackend            = Result(C.MA_FAILED_TO_INIT_BACKEND)
+	ErrFailedToOpenBackendDevice      = Result(C.MA_FAILED_TO_OPEN_BACKEND_DEVICE)
+	ErrFailedToStartBackendDevice     = Result(C.MA_FAILED_TO_START_BACKEND_DEVICE)
+	ErrFailedToStopBackendDevice      = Result(C.MA_FAILED_TO_STOP_BACKEND_DEVICE)
 )
-
 // errorFromResult returns error for result code.
 func errorFromResult(r Result) error {
 	switch r {
-	case Success:
+	case C.MA_SUCCESS:
 		return nil
-	case Error:
-		return ErrError
-	case InvalidArgs:
-		return ErrInvalidArgs
-	case InvalidPperation:
-		return ErrInvalidPperation
-	case OutOfMemory:
-		return ErrOutOfMemory
-	case AccessDenied:
-		return ErrAccessDenied
-	case TooLarge:
-		return ErrTooLarge
-	case Timeout:
-		return ErrTimeout
-	case FormatNotSupported:
-		return ErrFormatNotSupported
-	case DeviceTypeNotSupported:
-		return ErrDeviceTypeNotSupported
-	case ShareModeNotSupported:
-		return ErrShareModeNotSupported
-	case NoBackend:
-		return ErrNoBackend
-	case NoDevice:
-		return ErrNoDevice
-	case APINotFound:
-		return ErrAPINotFound
-	case InvalidDeviceConfig:
-		return ErrInvalidDeviceConfig
-	case DeviceBusy:
-		return ErrDeviceBusy
-	case DeviceNotInitialized:
-		return ErrDeviceNotInitialized
-	case DeviceNotStarted:
-		return ErrDeviceNotStarted
-	case DeviceUnavailable:
-		return ErrDeviceUnavailable
-	case FailedToMapDeviceBuffer:
-		return ErrFailedToMapDeviceBuffer
-	case FailedToUnmapDeviceBuffer:
-		return ErrFailedToUnmapDeviceBuffer
-	case FailedToInitBackend:
-		return ErrFailedToInitBackend
-	case FailedToReadDataFromDevice:
-		return ErrFailedToReadDataFromDevice
-	case FailedToReadDataFromClient:
-		return ErrFailedToReadDataFromClient
-	case FailedToSendDataToClient:
-		return ErrFailedToSendDataToClient
-	case FailedToSendDataToDevice:
-		return ErrFailedToSendDataToDevice
-	case FailedToOpenBackendDevice:
-		return ErrFailedToOpenBackendDevice
-	case FailedToStartBackendDevice:
-		return ErrFailedToStartBackendDevice
-	case FailedToStopBackendDevice:
-		return ErrFailedToStopBackendDevice
-	case FailedToConfigureBackendDevice:
-		return ErrFailedToConfigureBackendDevice
-	case FailedToCreateMutex:
-		return ErrFailedToCreateMutex
-	case FailedToCreateEvent:
-		return ErrFailedToCreateEvent
-	case FailedToCreateThread:
-		return ErrFailedToCreateThread
 	default:
-		return ErrError
+	return r
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -10,15 +10,17 @@ import "C"
 type Result int32
 
 func (self Result) Error() string {
-	return C.GoString(C.ma_result_description(C.ma_result(self)))
+	return errTag + C.GoString(C.ma_result_description(C.ma_result(self)))
 }
 
 
 
 
 // Errors.
+const (
+	errTag = "miniaudio: "
+)
 var (
-	errTag = "miniaudio"
 	//  General errors.
 	ErrGeneric            = Result(C.MA_ERROR)
 	ErrInvalidArgs      = Result(C.MA_INVALID_ARGS)


### PR DESCRIPTION
Make Result implement the error interface using ma_result_description get rid of the code that converted Miniaudio errors to Go errors, all Malgo functions now return errors of type Result under the hood and CGO now resolves error constants for us. This is a breaking change because while doing this, I found and had to remove a bunch of old error codes that were no longer defined in Miniaudio. The name ErrInvalidPperration was renamed to ErrInvalidOperation as well.