### PR TITLE
Conditionally compile with -latomic if on 32-bit arm linux

### DIFF
--- a/miniaudio.go
+++ b/miniaudio.go
@@ -6,6 +6,7 @@ package malgo
 #cgo ma_debug CFLAGS: -DMA_DEBUG_OUTPUT=1
 
 #cgo linux,!android LDFLAGS: -ldl -lpthread -lm
+#cgo linux,arm LDFLAGS: -latomic
 #cgo openbsd LDFLAGS: -ldl -lpthread -lm
 #cgo netbsd LDFLAGS: -ldl -lpthread -lm
 #cgo freebsd LDFLAGS: -ldl -lpthread -lm


### PR DESCRIPTION
When trying to use the malgo library on a 32-bit ARM linux computer (raspberry pi zero w) I received the following error:
```
# github.com/gen2brain/malgo
/usr/bin/ld: $WORK/b774/_x008.o: in function `ma_job_queue_post':
/home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:17008: undefined reference to `__atomic_load_8'
/usr/bin/ld: /home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:17009: undefined reference to `__atomic_load_8'
/usr/bin/ld: /home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:17011: undefined reference to `__atomic_load_8'
/usr/bin/ld: $WORK/b774/_x008.o: in function `ma_job_queue_next':
/home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:17082: undefined reference to `__atomic_load_8'
/usr/bin/ld: /home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:17083: undefined reference to `__atomic_load_8'
/usr/bin/ld: $WORK/b774/_x008.o:/home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:17084: more undefined references to `__atomic_load_8' follow
/usr/bin/ld: $WORK/b774/_x008.o: in function `ma_resource_manager_data_stream_set_absolute_cursor':
/home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:67073: undefined reference to `__atomic_exchange_8'
/usr/bin/ld: /home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:67073: undefined reference to `__atomic_exchange_8'
/usr/bin/ld: $WORK/b774/_x008.o: in function `ma_resource_manager_data_stream_seek_to_pcm_frame':
/home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:67523: undefined reference to `__atomic_load_8'
/usr/bin/ld: $WORK/b774/_x008.o: in function `ma_resource_manager_data_stream_set_absolute_cursor':
/home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:67073: undefined reference to `__atomic_exchange_8'
/usr/bin/ld: $WORK/b774/_x008.o: in function `ma_node_set_state_time':
/home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:70006: undefined reference to `__atomic_exchange_8'
/usr/bin/ld: $WORK/b774/_x008.o: in function `ma_node_get_state_time':
/home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:70022: undefined reference to `__atomic_load_8'
/usr/bin/ld: $WORK/b774/_x008.o: in function `ma_node_read_pcm_frames':
/home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:70447: undefined reference to `__atomic_fetch_add_8'
/usr/bin/ld: $WORK/b774/_x008.o: in function `ma_node_get_time':
/home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:70072: undefined reference to `__atomic_load_8'
/usr/bin/ld: $WORK/b774/_x008.o: in function `ma_node_set_time':
/home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:70081: undefined reference to `__atomic_exchange_8'
/usr/bin/ld: $WORK/b774/_x008.o: in function `ma_engine_node_process_pcm_frames__sound':
/home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:71824: undefined reference to `__atomic_load_8'
/usr/bin/ld: /home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:71831: undefined reference to `__atomic_exchange_8'
/usr/bin/ld: $WORK/b774/_x008.o: in function `ma_sound_seek_to_pcm_frame':
/home/pi/go/pkg/mod/github.com/gen2brain/malgo@v0.11.10/miniaudio.h:74014: undefined reference to `__atomic_exchange_8'
collect2: error: ld returned 1 exit status
```

This is corrected by conditionally compiling with the `-latomic` LDFLAG if on a 32-bit arm linux machine. Confirmed that this change fixes the problem locally.